### PR TITLE
Fix Help

### DIFF
--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -94,7 +94,7 @@ module.exports = function (controller) {
     }
   });
 
-  controller.hears(/誰？?$/, "direct_mention", async (bot, message) => {
+  controller.hears(/誰？$/, "direct_mention", async (bot, message) => {
     if (state.type === STARTED) {
       if (state.members.waiting.length > 0) {
         const remaining = state.members.waiting
@@ -215,24 +215,66 @@ controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
     }
   });
 
-  controller.hears(/^ヘルプ$/, "direct_mention", async (bot, message)) => {
+  controller.hears(/^ヘルプ$/, "direct_mention", async (bot, message) => {
     if (state.type === STARTED) {
-        // bot.sayとbot.replyの違いは何か？
-        // キーワードの一部分だけでも発言と一致していれば反応？例えば、trelloの作業ボードの添付ファイルにある画像で、「残りは誰？」に対しても反応している。
-
-      await bot.say(`
-                    :raising_hand: Shujinosukeで使えるコマンドは以下の通りです。
-                    開始              会議を開始します。
-                    終了              会議を終了します。
-                    参加              会議に参加します。
-                    キャンセル         参加を取り消します。
-                    誰？              レポート未投稿者を通知します。
-                    レポート           レポートを投稿します。
-`);
-    }
+        await bot.reply(message, {
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: ":point_down:Shujinosukeで使えるコマンドは以下の通りです:point_down:\nレポートの投稿\n`レポート` `<@U010MMQGD96> +レポート` `先週から注力してうまくいったこと` `苦戦していること` `来週にかけて注力すること`"
+              },
+            },
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "会議の開始\n`開始`"
+               },
+            },
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "会議の強制終了\n`終了` `リセット` `reset`"
+              },
+            },
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "会議へ参加\n`参加`"
+              },
+            },
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "参加の取り消し\n`キャンセル`"
+              },
+            },
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "レポート未投稿者の確認\n`誰？`"
+              },
+            },
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: "Botステータスの確認\n`status`"
+              },
+            },
+          ],
+        });
+      }
   });
-      
-                    
+
+  
+                
   controller.on("continue_session", async (bot, message) => {
     if (state.type === STARTED) {
       if (state.members.waiting.length > 0) {

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -153,7 +153,7 @@ ${JSON.stringify(state, null, 2)}
     }
   );
 
-controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
+  controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
     if (state.type === SLEEPING) {
       state.type = STARTED;
       setTimeout(async () => {
@@ -214,66 +214,66 @@ controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
       });
     }
   });
-      
+
   controller.hears(/^ヘルプ$/, "direct_mention", async (bot, message) => {
     if (state.type === STARTED) {
-        await bot.reply(message, {
-          blocks: [
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: ":point_down:Shujinosukeで使えるコマンドは以下の通りです:point_down:\nレポートの投稿\n`レポート` `<@U010MMQGD96> +レポート` `先週から注力してうまくいったこと` `苦戦していること` `来週にかけて注力すること`"
-              },
+      await bot.reply(message, {
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text:
+                ":point_down:Shujinosukeで使えるコマンドは以下の通りです:point_down:\nレポートの投稿\n`レポート` `<@U010MMQGD96> +レポート` `先週から注力してうまくいったこと` `苦戦していること` `来週にかけて注力すること`",
             },
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: "会議の開始\n`開始`"
-               },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "会議の開始\n`開始`",
             },
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: "会議の強制終了\n`終了` `リセット` `reset`"
-              },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "会議の強制終了\n`終了` `リセット` `reset`",
             },
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: "会議へ参加\n`参加`"
-              },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "会議へ参加\n`参加`",
             },
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: "参加の取り消し\n`キャンセル`"
-              },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "参加の取り消し\n`キャンセル`",
             },
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: "レポート未投稿者の確認\n`誰？`"
-              },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "レポート未投稿者の確認\n`誰？`",
             },
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: "Botステータスの確認\n`status`"
-              },
+          },
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "Botステータスの確認\n`status`",
             },
-          ],
-        });
-      }
+          },
+        ],
+      });
+    }
   });
 
-  
   controller.on("continue_session", async (bot, message) => {
     if (state.type === STARTED) {
       if (state.members.waiting.length > 0) {

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -153,7 +153,7 @@ ${JSON.stringify(state, null, 2)}
     }
   );
 
-  controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
+controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
     if (state.type === SLEEPING) {
       state.type = STARTED;
       setTimeout(async () => {
@@ -215,6 +215,24 @@ ${JSON.stringify(state, null, 2)}
     }
   });
 
+  controller.hears(/^ヘルプ$/, "direct_mention", async (bot, message)) => {
+    if (state.type === STARTED) {
+        // bot.sayとbot.replyの違いは何か？
+        // キーワードの一部分だけでも発言と一致していれば反応？例えば、trelloの作業ボードの添付ファイルにある画像で、「残りは誰？」に対しても反応している。
+
+      await bot.say(`
+                    :raising_hand: Shujinosukeで使えるコマンドは以下の通りです。
+                    開始              会議を開始します。
+                    終了              会議を終了します。
+                    参加              会議に参加します。
+                    キャンセル         参加を取り消します。
+                    誰？              レポート未投稿者を通知します。
+                    レポート           レポートを投稿します。
+`);
+    }
+  });
+      
+                    
   controller.on("continue_session", async (bot, message) => {
     if (state.type === STARTED) {
       if (state.members.waiting.length > 0) {

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -13,6 +13,49 @@ let state = {
   },
 };
 
+const help_commands_off = {
+  会議の開始: "`開始`",
+  Botステータスの確認: "`status`",
+  ping: "`ping`",
+  ヘルプ: "`ヘルプ` `help`",
+};
+const help_commands_on = {
+  レポートの投稿:
+    "`レポート` `先週から注力してうまくいったこと`\n`苦戦していること` `来週にかけて注力すること`",
+  会議の開始: "`開始`",
+  会議の強制終了: "`終了` `リセット` `reset`",
+  会議へ参加: "`参加`",
+  参加の取り消し: "`キャンセル`",
+  レポート未投稿者の確認: "`誰？`",
+  Botステータスの確認: "`status`",
+  ping: "`ping`",
+  ヘルプ: "`ヘルプ` `help`",
+};
+
+function gen_message() {
+  let message_txt;
+  if (state.type === SLEEPING) {
+    let help_commnads_off_array = [
+      ':books:会議開始前にShujinosukeで使えるコマンドは以下の通りです！\n:bulb:コマンドの前には必ず "@Shujinosuke" をつけましょう！',
+    ];
+    for (let key in help_commands_off) {
+      help_commnads_off_array.push(
+        "\n\n" + key + "\n" + help_commands_off[key]
+      );
+    }
+    message_txt = help_commnads_off_array.join(",").split(",").join(" ");
+  } else if (state.type === STARTED) {
+    let help_commnads_on_array = [
+      ':books:会議中にShujinosukeで使えるコマンドは以下の通りです！\n:bulb:コマンドの前には必ず "@Shujinosuke" をつけましょう！',
+    ];
+    for (let key in help_commands_on) {
+      help_commnads_on_array.push("\n\n" + key + "\n" + help_commands_on[key]);
+    }
+    message_txt = help_commnads_on_array.join(",").split(",").join(" ");
+  }
+  return message_txt;
+}
+
 async function join(bot, message) {
   if (state.type == STARTED && message.user) {
     if (
@@ -218,78 +261,8 @@ ${JSON.stringify(state, null, 2)}
     /^(ヘルプ|help)$/,
     "direct_mention",
     async (bot, message) => {
-      const help_commands_off = {
-        会議の開始: "`開始`",
-        Botステータスの確認: "`status`",
-        ping: "`ping`",
-        ヘルプ: "`ヘルプ` `help`",
-      };
-      const help_commands_on = {
-        レポートの投稿:
-          "`レポート` `先週から注力してうまくいったこと`\n`苦戦していること` `来週にかけて注力すること`",
-        会議の開始: "`開始`",
-        会議の強制終了: "`終了` `リセット` `reset`",
-        会議へ参加: "`参加`",
-        参加の取り消し: "`キャンセル`",
-        レポート未投稿者の確認: "`誰？`",
-        Botステータスの確認: "`status`",
-        ping: "`ping`",
-        ヘルプ: "`ヘルプ` `help`",
-      };
-
-      let message_array = [];
-      if (state.type === SLEEPING) {
-        for (let key in help_commands_off) {
-          message_array.push(key + "\n" + help_commands_off[key] + "\n\n");
-        }
-        message_txt = message_array.join(",").split(",").join(" ");
-        await bot.reply(message, {
-          blocks: [
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text:
-                  ":point_down:会議開始前にShujinosukeで使えるコマンドは以下の通りです:point_down:",
-              },
-            },
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: message_txt,
-              },
-            },
-          ],
-        });
-      }
-
-      if (state.type === STARTED) {
-        for (let key in help_commands_on) {
-          message_array.push(key + "\n" + help_commands_on[key] + "\n\n");
-        }
-        message_txt = message_array.join(",").split(",").join(" ");
-
-        await bot.reply(message, {
-          blocks: [
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text:
-                  ":point_down:会議中にShujinosukeで使えるコマンドは以下の通りです:point_down:",
-              },
-            },
-            {
-              type: "section",
-              text: {
-                type: "mrkdwn",
-                text: message_txt,
-              },
-            },
-          ],
-        });
-      }
+      let message_txt = gen_message();
+      await bot.reply(message, message_txt);
     }
   );
 

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -214,7 +214,7 @@ controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
       });
     }
   });
-
+      
   controller.hears(/^ヘルプ$/, "direct_mention", async (bot, message) => {
     if (state.type === STARTED) {
         await bot.reply(message, {
@@ -274,7 +274,6 @@ controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
   });
 
   
-                
   controller.on("continue_session", async (bot, message) => {
     if (state.type === STARTED) {
       if (state.members.waiting.length > 0) {

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -214,65 +214,84 @@ ${JSON.stringify(state, null, 2)}
       });
     }
   });
+  controller.hears(
+    /^(ヘルプ|help)$/,
+    "direct_mention",
+    async (bot, message) => {
+      const help_commands_off = {
+        会議の開始: "`開始`",
+        Botステータスの確認: "`status`",
+        ping: "`ping`",
+        ヘルプ: "`ヘルプ` `help`",
+      };
+      const help_commands_on = {
+        レポートの投稿:
+          "`レポート` `先週から注力してうまくいったこと`\n`苦戦していること` `来週にかけて注力すること`",
+        会議の開始: "`開始`",
+        会議の強制終了: "`終了` `リセット` `reset`",
+        会議へ参加: "`参加`",
+        参加の取り消し: "`キャンセル`",
+        レポート未投稿者の確認: "`誰？`",
+        Botステータスの確認: "`status`",
+        ping: "`ping`",
+        ヘルプ: "`ヘルプ` `help`",
+      };
 
-  controller.hears(/^ヘルプ$/, "direct_mention", async (bot, message) => {
-    if (state.type === STARTED) {
-      await bot.reply(message, {
-        blocks: [
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text:
-                ":point_down:Shujinosukeで使えるコマンドは以下の通りです:point_down:\nレポートの投稿\n`レポート` `<@U010MMQGD96> +レポート` `先週から注力してうまくいったこと` `苦戦していること` `来週にかけて注力すること`",
+      let message_array = [];
+      if (state.type === SLEEPING) {
+        for (let key in help_commands_off) {
+          message_array.push(key + "\n" + help_commands_off[key] + "\n\n");
+        }
+        message_txt = message_array.join(",").split(",").join(" ");
+        await bot.reply(message, {
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text:
+                  ":point_down:会議開始前にShujinosukeで使えるコマンドは以下の通りです:point_down:",
+              },
             },
-          },
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: "会議の開始\n`開始`",
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: message_txt,
+              },
             },
-          },
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: "会議の強制終了\n`終了` `リセット` `reset`",
+          ],
+        });
+      }
+
+      if (state.type === STARTED) {
+        for (let key in help_commands_on) {
+          message_array.push(key + "\n" + help_commands_on[key] + "\n\n");
+        }
+        message_txt = message_array.join(",").split(",").join(" ");
+
+        await bot.reply(message, {
+          blocks: [
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text:
+                  ":point_down:会議中にShujinosukeで使えるコマンドは以下の通りです:point_down:",
+              },
             },
-          },
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: "会議へ参加\n`参加`",
+            {
+              type: "section",
+              text: {
+                type: "mrkdwn",
+                text: message_txt,
+              },
             },
-          },
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: "参加の取り消し\n`キャンセル`",
-            },
-          },
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: "レポート未投稿者の確認\n`誰？`",
-            },
-          },
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: "Botステータスの確認\n`status`",
-            },
-          },
-        ],
-      });
+          ],
+        });
+      }
     }
-  });
+  );
 
   controller.on("continue_session", async (bot, message) => {
     if (state.type === STARTED) {


### PR DESCRIPTION
ヘルプコマンドを付け加えたコードになります。

試しに書いていた「ヘルプ」を修正した上で、Slack上で動作確認を行いました。
Slackのmrkdwn記法による inline code がバッククオートを使用しているため、各コマンドごとブロックごとに分け、発言の部分は全体をダブルクオートで囲む形を取っています。そのためかなり冗長になってしまいました