### PR TITLE
Multichannel_state

### DIFF
--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -206,10 +206,7 @@ ${JSON.stringify(Array.from(channel_state), null, 2)}
   controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
     if (state.type === SLEEPING) {
       state.type = STARTED;
-      channel_state.set(message.channel, {
-        type: STARTED,
-        members: { waiting: [], done: [] },
-      });
+      channel_state.set(message.channel, { waiting: [], done: [] });
       setTimeout(async () => {
         await bot.changeContext(message.reference);
         controller.trigger("continue_session", bot, message);

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -13,6 +13,8 @@ let state = {
   },
 };
 
+let channel_state = new Map();
+
 const help_commands_off = {
   会議の開始: "`開始`",
   Botステータスの確認: "`status`",
@@ -196,7 +198,11 @@ ${JSON.stringify(state, null, 2)}
 
   controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
     if (state.type === SLEEPING) {
-      state.type = STARTED;
+      //state.type = STARTED;
+      channel_state.set(message.channel, {
+        type: STARTED,
+        members: { waiting: [], done: [] },
+      });
       setTimeout(async () => {
         await bot.changeContext(message.reference);
         controller.trigger("continue_session", bot, message);

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -8,12 +8,6 @@ const ENDING_PERIOD_SECONDS = 300;
 
 let channel_state = new Map();
 
-function remove_state_element(message) {
-  if (channel_state.has(message.channel)) {
-    channel_state.delete(message.channel);
-  }
-}
-
 const help_commands_off = {
   会議の開始: "`開始`",
   Botステータスの確認: "`status`",
@@ -162,7 +156,7 @@ module.exports = function (controller) {
     "direct_mention",
     async (bot, message) => {
       const state_dump = JSON.stringify(Array.from(channel_state), null, 2);
-      remove_state_element(message);
+      channel_state.delete(message.channel);
       await bot.say(`
 リセットします。直前の状態は以下のようになっていました:
 \`\`\`
@@ -288,8 +282,7 @@ ${JSON.stringify(Array.from(channel_state), null, 2)}
   });
 
   controller.on("end_session", async (bot, message) => {
-    if (channel_state.has(message.channel)) {
-      remove_state_element(message);
+    if (channel_state.delete(message.channel)) {
       await bot.say(`
 :stopwatch: 時間になりました！ みなさんご協力ありがとうございました。 :bow:
 :rainbow: リフレッシュして、業務に戻りましょう！ :notes:

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -164,7 +164,7 @@ module.exports = function (controller) {
     /^(終了|リセット|reset)$/,
     "direct_mention",
     async (bot, message) => {
-      const state_dump = JSON.stringify(state, null, 2);
+      const state_dump = JSON.stringify(Array.from(channel_state), null, 2);
       state = {
         type: SLEEPING,
         members: { waiting: [], done: [] },
@@ -182,7 +182,7 @@ ${state_dump}
   controller.hears(/^status$/, "direct_mention", async (bot, message) => {
     await bot.say(`
 \`\`\`
-${JSON.stringify(state, null, 2)}
+${JSON.stringify(Array.from(channel_state), null, 2)}
 \`\`\`
 `);
   });
@@ -196,7 +196,7 @@ ${JSON.stringify(state, null, 2)}
         `
 pong!
 \`\`\`
-${JSON.stringify(state, null, 2)}
+${JSON.stringify(Array.from(channel_state), null, 2)}
 \`\`\`
 `
       );

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -15,6 +15,12 @@ let state = {
 
 let channel_state = new Map();
 
+function remove_state_element(message) {
+  if (channel_state.has(message.channel)) {
+    channel_state.delete(message.channel);
+  }
+}
+
 const help_commands_off = {
   会議の開始: "`開始`",
   Botステータスの確認: "`status`",
@@ -163,6 +169,7 @@ module.exports = function (controller) {
         type: SLEEPING,
         members: { waiting: [], done: [] },
       };
+      remove_state_element(message);
       await bot.say(`
 リセットします。直前の状態は以下のようになっていました:
 \`\`\`
@@ -198,7 +205,7 @@ ${JSON.stringify(state, null, 2)}
 
   controller.hears(/^開始$/, "direct_mention", async (bot, message) => {
     if (state.type === SLEEPING) {
-      //state.type = STARTED;
+      state.type = STARTED;
       channel_state.set(message.channel, {
         type: STARTED,
         members: { waiting: [], done: [] },
@@ -295,6 +302,7 @@ ${JSON.stringify(state, null, 2)}
     if (state.type === STARTED) {
       state.type = SLEEPING;
       state.members = { waiting: [], done: [] };
+      remove_state_element(message);
       await bot.say(`
 :stopwatch: 時間になりました！ みなさんご協力ありがとうございました。 :bow:
 :rainbow: リフレッシュして、業務に戻りましょう！ :notes:

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -33,7 +33,7 @@ const help_commands_on = {
   ヘルプ: "`ヘルプ` `help`",
 };
 
-function gen_help_message() {
+function gen_help_message(message) {
   if (!channel_state.has(message.channel)) {
     const commands = Object.entries(help_commands_off)
       .map(([key, val]) => key + "\n" + val)
@@ -262,7 +262,7 @@ ${JSON.stringify(Array.from(channel_state), null, 2)}
     /^(ヘルプ|help)$/,
     "direct_mention",
     async (bot, message) => {
-      let message_txt = gen_help_message();
+      let message_txt = gen_help_message(message);
       await bot.reply(message, message_txt);
     }
   );


### PR DESCRIPTION
Shujinosuke複数チャンネル対応化用のPRとなります。
現時点でmasterに先行するcommitが3つありますが、それぞれ

- 「開始」と同時にチャンネルIDを持ったMap型変数 `channel_ID, {type: STARTED, members: {waiting: [], done: []}}` の生成

- （強制）終了と共に週次が終了したチャンネルの変数をchannel_stateから削除

-  `status`, `reset`, `ping` コマンドでchannel_stateの様子を伝える

という機能が含まれています。ご確認をお願いします。
今後は条件分岐 `state.type === STARTED`を `channel_state.has(channel_ID)` に変更する作業を行っていきます。