### PR TITLE
Updating nodejs 12.18.4

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-nodejs 10.19.0
+nodejs 12.18.4
 yarn 1.22.4

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "bot.js",
   "private": true,
   "engines": {
-    "node": "10",
+    "node": "12",
     "yarn": "1.22"
   },
   "scripts": {

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -156,7 +156,11 @@ module.exports = function (controller) {
     /^(終了|リセット|reset)$/,
     "direct_mention",
     async (bot, message) => {
-      const state_dump = JSON.stringify(Array.from(global_state), null, 2);
+      const state_dump = JSON.stringify(
+        Object.fromEntries(global_state),
+        null,
+        2
+      );
       global_state.delete(message.channel);
       await bot.say(`
 リセットします。直前の状態は以下のようになっていました:
@@ -170,7 +174,7 @@ ${state_dump}
   controller.hears(/^status$/, "direct_mention", async (bot, message) => {
     await bot.say(`
 \`\`\`
-${JSON.stringify(Array.from(global_state), null, 2)}
+${JSON.stringify(Object.fromEntries(global_state), null, 2)}
 \`\`\`
 `);
   });
@@ -184,7 +188,7 @@ ${JSON.stringify(Array.from(global_state), null, 2)}
         `
 pong!
 \`\`\`
-${JSON.stringify(Array.from(global_state), null, 2)}
+${JSON.stringify(Object.fromEntries(global_state), null, 2)}
 \`\`\`
 `
       );

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -39,8 +39,8 @@ function gen_help_message(message) {
     );
   } else if (global_state.has(message.channel)) {
     const commands = Object.entries(help_commands_on)
-      .map((x) => "\n" + x[0] + "\n" + x[1])
-      .join("\n");
+      .map(([key, val]) => key + "\n" + val)
+      .join("\n\n");
 
     return (
       ':books:会議中にShujinosukeで使えるコマンドは以下の通りです！\n:bulb:コマンドの前には必ず "@Shujinosuke" をつけましょう！\n\n' +
@@ -262,7 +262,7 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
     "direct_mention",
     async (bot, message) => {
       let message_txt = gen_help_message(message);
-      await bot.reply(message, message_txt);
+      await bot.replyEphemeral(message, message_txt);
     }
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -130,11 +130,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/color-name@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
-  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
 "@types/is-stream@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
@@ -158,14 +153,14 @@
     "@types/node" "*"
 
 "@types/node@*", "@types/node@>=8.9.0":
-  version "14.11.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.2.tgz#2de1ed6670439387da1c9f549a2ade2b0a799256"
-  integrity sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA==
+  version "14.11.8"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.11.8.tgz#fe2012f2355e4ce08bca44aeb3abbb21cf88d33f"
+  integrity sha512-KPcKqKm5UKDkaYPTuXSx8wEP7vE9GnuaXIZKijwRYcePpZFDVuy2a57LarFKiORbHOuTOOwYzxVxcUzsh2P2Pw==
 
 "@types/node@^10.17.27":
-  version "10.17.35"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.35.tgz#58058f29b870e6ae57b20e4f6e928f02b7129f56"
-  integrity sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA==
+  version "10.17.39"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.39.tgz#ce1122758d0608de8303667cebf171f44192629b"
+  integrity sha512-dJLCxrpQmgyxYGcl0Ae9MTsQgI22qHHcGFj/8VKu7McJA5zQpnuGjoksnxbo1JxSjW/Nahnl13W8MYZf01CZHA==
 
 "@types/node@^8.0.47":
   version "8.10.64"
@@ -252,11 +247,10 @@ ansi-regex@^5.0.0:
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
 ansi-styles@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
-  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
-    "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
 anymatch@~3.1.1:
@@ -1489,9 +1483,9 @@ moment-timezone@^0.5.28:
     moment ">= 2.9.0"
 
 "moment@>= 2.9.0", moment@^2.24.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.0.tgz#fcbef955844d91deb55438613ddcec56e86a3425"
-  integrity sha512-z6IJ5HXYiuxvFTI6eiQ9dm77uE0gyy1yXNApVHqTcnIKfY9tIwEjlzsZ6u1LQXvVgKeTnv9Xm7NDvJ7lso3MtA==
+  version "2.29.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
+  integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
 mongodb@^3.6.0:
   version "3.6.2"
@@ -2047,9 +2041,9 @@ trim-repeated@^1.0.0:
     escape-string-regexp "^1.0.2"
 
 tslib@^1.9.2:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
-  integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.0.tgz#d624983f3e2c5e0b55307c3dd6c86acd737622c6"
+  integrity sha512-+Zw5lu0D9tvBMjGP8LpvMb0u2WW2QV3y+D8mO6J+cNzCYIN4sVy43Bf9vl92nqFahutN0I8zHa7cc4vihIshnw==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"


### PR DESCRIPTION
以下変更内容です。

- shujinosukeのnodejsを v12.18.4にアップデートしました。また、同時に yarn upgrade も実行しました。
- `@Shujinosuke status` 等、statusをJSON形式で返答するものについて、`Object.fromEntries` を使用しました。
- `@Shujinosuke ヘルプ` の応答を `replyEphemeral` に変更しました。
- "gen_help_message"中で会議中のヘルプコマンドのみ.map中で destructuring を使っていなかったため、変更しました。(line 42 - 43)

動作確認済みです。レビューをお願いします。
先ほど間違えてPRしたブランチ "node_version"は削除していただいて構わないです。