### PR TITLE
Post when emoji added

### DIFF
--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -300,9 +300,12 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
 
   controller.on("add", async (bot, message) => {
     if (message.subtype === "add") {
-      const emoji_added_txt = `新しいカスタム絵文字 :${message.name}: が追加されました！`;
+      const emoji_added_txt = `
+新しいカスタム絵文字 :${message.name}: が追加されました！
+エイリアスは \"${message.name}\"です！
+      `;
       await bot.api.chat.postMessage({
-        channel: "C01AQPDC9S4",
+        channel: "C01CAKK0TQ9",
         text: emoji_added_txt,
       });
     }

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -298,11 +298,11 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
     }
   );
 
-  controller.on("emoji_changed", async (bot, message) => {
+  controller.on("add", async (bot, message) => {
     if (message.subtype === "add") {
       const emoji_added_txt = `新しいカスタム絵文字 :${message.name}: が追加されました！`;
       await bot.api.chat.postMessage({
-        channel: "C01CAKK0TQ9",
+        channel: "C01AQPDC9S4",
         text: emoji_added_txt,
       });
     }

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -301,11 +301,8 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
   controller.on("add", async (bot, message) => {
     if (message.subtype === "add") {
       await bot.api.chat.postMessage({
-        channel: "C011BG29K71",
-        text: `
-新しいカスタム絵文字 :${message.name}: が追加されました！
-エイリアスは \"${message.name}\" です！
-`,
+        channel: "C011BG29K71", //post to "雑談" channel
+        text: `:${message.name}:  (\`:${message.name}:\`)が追加されました！`,
       });
     }
   });

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -298,6 +298,16 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
     }
   );
 
+  controller.on("emoji_changed", async (bot, message) => {
+    if (message.subtype === "add") {
+      const emoji_added_txt = `新しいカスタム絵文字 :${message.name}: が追加されました！`;
+      await bot.api.chat.postMessage({
+        channel: "C01CAKK0TQ9",
+        text: emoji_added_txt,
+      });
+    }
+  });
+
   controller.on("reply_attendees", async (bot, message) => {
     const message_txt = `
   :male-technologist: こちらが現在Slack上でアクティブな方々です！

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -300,13 +300,12 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
 
   controller.on("add", async (bot, message) => {
     if (message.subtype === "add") {
-      const emoji_added_txt = `
-新しいカスタム絵文字 :${message.name}: が追加されました！
-エイリアスは \"${message.name}\"です！
-      `;
       await bot.api.chat.postMessage({
-        channel: "C01CAKK0TQ9",
-        text: emoji_added_txt,
+        channel: "C011BG29K71",
+        text: `
+新しいカスタム絵文字 :${message.name}: が追加されました！
+エイリアスは \"${message.name}\" です！
+`,
       });
     }
   });


### PR DESCRIPTION
カスタム絵文字が追加された際に、＃雑談 に通知する機能を実装しました。
emoji追加/削除時のslackでの公式なevent名は `emoji_changed` ですが、botkitのバグにより、 `.on("add")` でないとイベントの処理ができないようです。
レビューをお願いします。