### PR TITLE
Adjust wake words

### DIFF
--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -296,7 +296,7 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
   );
 
   controller.hears(
-    /^(誰いる[？?]?||今?いる人.*||)$/,
+    /^(誰いる[？?]?|今?いる人.*)$/,
     "direct_mention",
     async (bot, message) => {
       await bot.changeContext(message.reference);

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -23,7 +23,7 @@ const help_commands_on = {
   会議の強制終了: "`終了` `リセット` `reset`",
   会議へ参加: "`参加`",
   参加の取り消し: "`キャンセル`",
-  レポート未投稿者の確認: "`誰？`",
+  レポート未投稿者の確認: "`誰？` `残りは？`",
   Botステータスの確認: "`status`",
   ping: "`ping`",
   ヘルプ: "`ヘルプ` `help`",
@@ -153,23 +153,29 @@ module.exports = function (controller) {
     }
   });
 
-  controller.hears(/誰？$/, "direct_mention", async (bot, message) => {
-    let channel_state = global_state.get(message.channel);
-    if (channel_state) {
-      if (channel_state.waiting.length > 0) {
-        const remaining = channel_state.waiting
-          .map((value, _index, _array) => `<@${value}>`)
-          .join(", ");
-        await bot.say(`
+  controller.hears(
+    /(^残りは[？?]?|誰[？?]?$)/,
+    "direct_mention",
+    async (bot, message) => {
+      let channel_state = global_state.get(message.channel);
+      if (channel_state) {
+        if (channel_state.waiting.length > 0) {
+          const remaining = channel_state.waiting
+            .map((value, _index, _array) => `<@${value}>`)
+            .join(", ");
+          await bot.say(`
 :point_right: 残りは${remaining}です。
 :fast_forward: 急用ができたら「 *@Shujinosuke キャンセル* 」もできます。
 :question: 私がちゃんと反応しなかった場合、削除して投稿し直してみてください。
 `);
-      } else {
-        await bot.say(":point_up: 今は全体連絡とレポートレビューの時間です。");
+        } else {
+          await bot.say(
+            ":point_up: 今は全体連絡とレポートレビューの時間です。"
+          );
+        }
       }
     }
-  });
+  );
 
   controller.hears(
     /^(終了|リセット|reset)$/i,

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -172,7 +172,7 @@ module.exports = function (controller) {
   });
 
   controller.hears(
-    /^(終了|リセット|reset)$/,
+    /^(終了|リセット|reset)$/i,
     "direct_mention",
     async (bot, message) => {
       const state_dump = JSON.stringify(
@@ -190,7 +190,7 @@ ${state_dump}
     }
   );
 
-  controller.hears(/^status$/, "direct_mention", async (bot, message) => {
+  controller.hears(/^status$/i, "direct_mention", async (bot, message) => {
     await bot.say(`
 \`\`\`
 ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
@@ -199,7 +199,7 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
   });
 
   controller.hears(
-    /^ping$/,
+    /^ping$/i,
     "direct_mention,direct_message",
     async (bot, message) => {
       await bot.replyEphemeral(
@@ -281,7 +281,7 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
   });
 
   controller.hears(
-    /^(ヘルプ|help)$/,
+    /^(ヘルプ|help)$/i,
     "direct_mention",
     async (bot, message) => {
       let message_txt = gen_help_message(message);

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -290,7 +290,7 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
   );
 
   controller.hears(
-    /^(誰いる？||今いる人は？)$/,
+    /^(誰いる[？?]?||今?いる人.*||)$/,
     "direct_mention",
     async (bot, message) => {
       await bot.changeContext(message.reference);


### PR DESCRIPTION
Wake wordsのちょっとした調整を行いました。
調整内容としては、

- "？"を日本語入力、ローマ字入力の両方に対応

- 英単語の場合は、大文字でも反応(`i`)

- `今いる人は？` が長すぎるので、 `いる人` で対応可能に。（全部入力しても反応します。）

- 会議中の未レポート者の確認に `残りは？` を追加。 `残りは誰？` でも実行可能。

- wake word 変更に伴う `help` コマンドの内容変更 