### PR TITLE
Remove deliverables doables from report template

### DIFF
--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -107,12 +107,7 @@ module.exports = function (controller) {
 
   // Pickup reports. This is the most prioritized pattern in the session.
   controller.hears(
-    [
-      /^レポート/,
-      /今週のdeliverables \/ doables/,
-      /調子、出来事、悩み等/,
-      /来週のdeliverables \/ doables/,
-    ],
+    [/^レポート/, /調子、出来事、悩み等/],
     "direct_mention,mention,message",
     async (bot, message) => {
       let channel_state = global_state.get(message.channel);

--- a/src/features/shujinosuke.js
+++ b/src/features/shujinosuke.js
@@ -17,8 +17,7 @@ const help_commands_off = {
   アクティブメンバーの確認: "`誰いる？` `今いる人は？`",
 };
 const help_commands_on = {
-  レポートの投稿:
-    "`レポート` `<規定タイトル（例: 今週のdeliverables / doables）を含む文章>`",
+  レポートの投稿: "`レポート` `調子、出来事、悩み等`",
   会議の開始: "`開始`",
   会議の強制終了: "`終了` `リセット` `reset`",
   会議へ参加: "`参加`",
@@ -251,16 +250,9 @@ ${JSON.stringify(Object.fromEntries(global_state), null, 2)}
             text: {
               type: "mrkdwn",
               text: `
-*1. 今週のdeliverables / doables *
-... / ...
-... / ...
-... / ...
-*2. 調子、出来事、悩み等 *
+@Shujinosuke レポート
+*・ 調子、出来事、悩み等*
 ...
-*3. 来週のdeliverables / doables *
-... / ...
-... / ...
-... / ...
 `,
             },
           },


### PR DESCRIPTION
[こちらのTrelloカードのコメント](https://trello.com/c/jJQoE37F/864-%E6%96%B0huddle%E3%83%95%E3%82%A9%E3%83%BC%E3%83%9E%E3%83%83%E3%83%88%E3%81%AB%E5%90%88%E3%82%8F%E3%81%9B%E3%81%9F%E9%80%B1%E6%AC%A1%E4%B9%8B%E4%BB%8B%E3%83%AA%E3%83%8B%E3%83%A5%E3%83%BC%E3%82%A2%E3%83%AB)に基づき、レポートのテンプレートから「今週(来週)のdeliverables / doables」を削除しました。
また、同カード内で指摘のあった「@shujinosuke レポート」については、テンプレートに再追加しました。