### PR TITLE
Change state management

### DIFF
--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -10,8 +10,6 @@ const EMOJI_EVENT_POST_CHANNEL = "C011BG29K71" // #雑談
 const CHECK_TIMEOUT_SECONDS = 1200;
 const ENDING_PERIOD_SECONDS = 300;
 const CALL_REMINDER_SECONDS = 180;
-const LOCK_TIMEOUT_SECONDS = 10;
-
 
 const isJson = (e: GoogleAppsScript.Events.DoPost) => {
   return e.postData.type === 'application/json';
@@ -77,89 +75,65 @@ const abortSession = (channelId: string) => {
 const sendReminderForJoin = async () => {
   const exceptions = ["U010MMQGD96", "UU8H6MKEU"]; //Shujinosuke and observers
   const client = getSlackClient();
-  const scriptLock = LockService.getScriptLock();
-  try {
-    scriptLock.waitLock(LOCK_TIMEOUT_SECONDS * 1000);
-    const sessionChannelId = getSessionChannelId();
-    const channelState = getChannelState(sessionChannelId);
-    const channelMembers = (await client.conversations.members({
-      channel: sessionChannelId
-    })).members.filter(userId => !exceptions.includes(userId));
-    const remindTargets = channelMembers.filter(userId => {
-      return (
-        !channelState.done.includes(userId) &&
-        !channelState.waiting.includes(userId)
-      )
-    });
-    remindTargets.forEach(async (remindTarget) => {
-      if ((await client.users.getPresence({ user: remindTarget })).presence === 'active') {
-        client.chat.postEphemeral({
-          channel: sessionChannelId,
-          user: remindTarget,
-          text: (
-            `:white_check_mark: <@${remindTarget}>さん、今週の週次が始まっています！` +
-            `:old_key: 参加する場合は 「参加」ボタンをクリックか、 \`@Shujinosuke 参加\` と発言してください！`
-          )
-        })
-      }
-    });
-  } catch (e) {
-    console.error(e);
-  } finally {
-    scriptLock.releaseLock();
-  }
+  const sessionChannelId = getSessionChannelId();
+  const channelState = getChannelState(sessionChannelId);
+  const channelMembers = (await client.conversations.members({
+    channel: sessionChannelId
+  })).members.filter(userId => !exceptions.includes(userId));
+  const remindTargets = channelMembers.filter(userId => {
+    return (
+      !channelState.done.includes(userId) &&
+      !channelState.waiting.includes(userId)
+    )
+  });
+  remindTargets.forEach(async (remindTarget) => {
+    if ((await client.users.getPresence({ user: remindTarget })).presence === 'active') {
+      client.chat.postEphemeral({
+        channel: sessionChannelId,
+        user: remindTarget,
+        text: (
+          `:white_check_mark: <@${remindTarget}>さん、今週の週次が始まっています！` +
+          `:old_key: 参加する場合は 「参加」ボタンをクリックか、 \`@Shujinosuke 参加\` と発言してください！`
+        )
+      })
+    }
+  });
 }
 
 
 const sendReminderForEndSession = () => {
-  const scriptLock = LockService.getScriptLock();
-  try {
-    scriptLock.waitLock(LOCK_TIMEOUT_SECONDS * 1000);
-    const client = getSlackClient();
-    const sessionChannelId = getSessionChannelId();
-    const channelState = getChannelState(sessionChannelId);
-    if (channelState?.waiting.length) {
-      client.chat.postMessage({
-        channel: sessionChannelId,
-        text: (
-          `:stopwatch: あと${channelState.waiting.length}人です。全体連絡を先に始めていてもOKです。\n` +
-          `:question: 私がちゃんと反応しなかった場合、削除して投稿し直してみてください。`
-        )
-      })
-    } else {
-      abortSession(sessionChannelId);
-      client.chat.postMessage({
-        channel: sessionChannelId,
-        text: `:fast_forward: 終了します。`
-      })
-    }
-  } catch (e) {
-    console.error(e);
-  } finally {
-    scriptLock.releaseLock();
+  const client = getSlackClient();
+  const sessionChannelId = getSessionChannelId();
+  const channelState = getChannelState(sessionChannelId);
+  if (channelState?.waiting.length) {
+    client.chat.postMessage({
+      channel: sessionChannelId,
+      text: (
+        `:stopwatch: あと${channelState.waiting.length}人です。全体連絡を先に始めていてもOKです。\n` +
+        `:question: 私がちゃんと反応しなかった場合、削除して投稿し直してみてください。`
+      )
+    })
+  } else {
+    abortSession(sessionChannelId);
+    client.chat.postMessage({
+      channel: sessionChannelId,
+      text: `:fast_forward: 終了します。`
+    })
   }
 }
 
 const endSession = () => {
-  const scriptLock = LockService.getScriptLock();
-  try {
-    scriptLock.waitLock(LOCK_TIMEOUT_SECONDS * 1000);
-    const client = getSlackClient();
-    const sessionChannelId = getSessionChannelId();
-    if (getChannelState(sessionChannelId)) {
-      abortSession(sessionChannelId);
-      client.chat.postMessage({
-        channel: sessionChannelId,
-        text: (
-          `:stopwatch: 時間になりました！ みなさんご協力ありがとうございました。 :bow:\n` +
-          `:rainbow: リフレッシュして、業務に戻りましょう！ :notes:`
-        )
-      });
-    }
-  } catch (e) {
-    console.error(e);
-  } finally {
-    scriptLock.releaseLock();
+  const client = getSlackClient();
+  const sessionChannelId = getSessionChannelId();
+  if (getChannelState(sessionChannelId)) {
+    abortSession(sessionChannelId);
+    client.chat.postMessage({
+      channel: sessionChannelId,
+      text: (
+        `:stopwatch: 時間になりました！ みなさんご協力ありがとうございました。 :bow:\n` +
+        `:rainbow: リフレッシュして、業務に戻りましょう！ :notes:`
+      )
+    });
   }
 }
 
@@ -290,21 +264,13 @@ const doPost = (e: GoogleAppsScript.Events.DoPost) => {
   }
 
   const client = getSlackClient();
-  const scriptLock = LockService.getScriptLock();
-  try {
-    scriptLock.waitLock(LOCK_TIMEOUT_SECONDS * 1000);
-    if (isAction(e)) {
-      handleSlackAction(client, JSON.parse(e.parameter['payload']));
-    } else if (isEvent(e)) {
-      const event = JSON.parse(e.postData.contents).event as SlackEvent;
-      handleSlackEvent(client, event);
-    }
-  } catch (e) {
-    console.error(e);
-  } finally {
-    scriptLock.releaseLock();
-    return ContentService.createTextOutput('OK');
+  if (isAction(e)) {
+    handleSlackAction(client, JSON.parse(e.parameter['payload']));
+  } else if (isEvent(e)) {
+    const event = JSON.parse(e.postData.contents).event as SlackEvent;
+    handleSlackEvent(client, event);
   }
+  return ContentService.createTextOutput('OK');
 }
 
 const handleSlackAction = (client, payload: SlackAction) => {

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -47,7 +47,6 @@ interface ChannelState {
 
 const initializeSession = (channelId: string) => {
   setSessionChannelId(channelId);
-  initChannelState(channelId);
   ScriptApp.newTrigger(checkParticipants.name)
     .timeBased()
     .after(CALL_REMINDER_SECONDS * 1000)
@@ -197,7 +196,6 @@ const join = (client: SlackClient, channelId: string, userId: string) => {
     });
   } else {
     newChannelState.waiting.push(userId);
-    setChannelState(channelId, newChannelState);
     client.chat.postMessage({ channel: channelId, text: `:hand: <@${userId}> が参加しました` });
   }
 }
@@ -213,7 +211,6 @@ const leave = (client: SlackClient, channelId: string, userId: string) => {
     newChannelState.waiting = channelState.waiting.filter((_userId) => {
       return _userId !== userId
     });
-    setChannelState(channelId, newChannelState);
     client.chat.postMessage({ channel: channelId, text: `:wave: <@${userId}> がキャンセルしました` });
     checkAllReported(client, channelId);
   }
@@ -227,16 +224,7 @@ const makeDoneFromWaiting = (channelId: string, userId: string): ChannelState | 
   newChannelState.waiting = channelState.waiting.filter((_userId) => {
     return _userId !== userId
   });
-  setChannelState(channelId, newChannelState);
   return newChannelState;
-}
-
-const initChannelState = (channelId: string) => {
-  setChannelState(channelId, { waiting: [], done: [] });
-}
-
-const setChannelState = (channelId: string, newState: ChannelState) => {
-  PropertiesService.getScriptProperties().setProperty(channelId, JSON.stringify(newState));
 }
 
 const getChannelState = (channelId: string): ChannelState => {

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -68,7 +68,6 @@ const initializeSession = (channelId: string) => {
 
 const abortSession = (channelId: string) => {
   deleteSessionChannelId();
-  deleteChannelState(channelId);
   //TODO: 複数のチャンネルでShujinosukeを運用するのであれば、削除するTriggerを絞る必要がある
   ScriptApp.getProjectTriggers().forEach(trigger => {
     ScriptApp.deleteTrigger(trigger);
@@ -251,15 +250,6 @@ const getChannelState = (channelId: string): ChannelState => {
     waiting: waiting,
     done: done
   };
-}
-
-const deleteChannelState = (channelId: string) => {
-  if (getChannelState(channelId)) {
-    PropertiesService.getScriptProperties().deleteProperty(channelId);
-    return true;
-  } else {
-    return false;
-  }
 }
 
 const getSessionChannelId = () => {

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -240,8 +240,20 @@ const setChannelState = (channelId: string, newState: ChannelState) => {
 }
 
 const getChannelState = (channelId: string): ChannelState => {
-  let channelState = JSON.parse(PropertiesService.getScriptProperties().getProperty(channelId));
-  return channelState;
+  const properties = PropertiesService.getScriptProperties().getProperties();
+  const users = Object.entries(properties).filter(([key, value]) => {
+    return value.includes(channelId);
+  });
+  const waiting = users.filter(([_, value]) => {
+    return value.includes('waiting');
+  }).map(([key, _]) => { return key });
+  const done = users.filter(([_, value]) => {
+    return value.includes('done');
+  }).map(([key, _]) => { return key });
+  return {
+    waiting: waiting,
+    done: done
+  };
 }
 
 const deleteChannelState = (channelId: string) => {

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -44,6 +44,15 @@ interface ChannelState {
   done: string[]
 }
 
+type SessionUserState = 'waiting' | 'done';
+
+const setSessionUserState = (channelId: string, userId: string, userState: SessionUserState) => {
+  PropertiesService.getScriptProperties().setProperty(userId, `${channelId}-${userState}`);
+}
+
+const deleteSessionUserState = (userId: string) => {
+  PropertiesService.getScriptProperties().deleteProperty(userId);
+}
 
 const initializeSession = (channelId: string) => {
   setSessionChannelId(channelId);

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -201,13 +201,13 @@ const makeDoneFromWaiting = (channelId: string, userId: string): void => {
 
 const getChannelState = (channelId: string): ChannelState => {
   const properties = PropertiesService.getScriptProperties().getProperties();
-  const users = Object.entries(properties).filter(([key, value]) => {
+  const participants = Object.entries(properties).filter(([key, value]) => {
     return value.includes(channelId);
   });
-  const waiting = users.filter(([_, value]) => {
+  const waiting = participants.filter(([_, value]) => {
     return value.includes('waiting');
   }).map(([key, _]) => { return key });
-  const done = users.filter(([_, value]) => {
+  const done = participants.filter(([_, value]) => {
     return value.includes('done');
   }).map(([key, _]) => { return key });
   return {

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -56,7 +56,7 @@ const deleteSessionUserState = (userId: string) => {
 
 const initializeSession = (channelId: string) => {
   setSessionChannelId(channelId);
-  ScriptApp.newTrigger(checkParticipants.name)
+  ScriptApp.newTrigger(sendReminderForJoin.name)
     .timeBased()
     .after(CALL_REMINDER_SECONDS * 1000)
     .create();
@@ -74,7 +74,7 @@ const abortSession = (channelId: string) => {
   });
 }
 
-const checkParticipants = async () => {
+const sendReminderForJoin = async () => {
   const exceptions = ["U010MMQGD96", "UU8H6MKEU"]; //Shujinosuke and observers
   const client = getSlackClient();
   const scriptLock = LockService.getScriptLock();
@@ -563,7 +563,7 @@ const handleAppMention = (slackClient: SlackClient, appMentionEvent: AppMentionE
       channel: event.channel,
       text: 'check'
     })
-    checkParticipants();
+    sendReminderForJoin();
   })
 }
 
@@ -582,5 +582,5 @@ declare const global: any;
 global.doPost = doPost;
 global.init = init;
 global.continueSession = continueSession;
-global.checkParticipants = checkParticipants;
+global.checkParticipants = sendReminderForJoin;
 global.endSession = endSession;

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -66,6 +66,7 @@ const initializeSession = (channelId: string) => {
 
 const abortSession = (channelId: string) => {
   deleteSessionChannelId();
+  deleteChannelState(channelId);
   //TODO: 複数のチャンネルでShujinosukeを運用するのであれば、削除するTriggerを絞る必要がある
   ScriptApp.getProjectTriggers().forEach(trigger => {
     ScriptApp.deleteTrigger(trigger);
@@ -213,6 +214,16 @@ const getChannelState = (channelId: string): ChannelState => {
     waiting: waiting,
     done: done
   };
+}
+
+const deleteChannelState = (channelId: string): void => {
+  const properties = PropertiesService.getScriptProperties().getProperties();
+  const participants = Object.entries(properties).filter(([key, value]) => {
+    return value.includes(channelId);
+  });
+  participants.forEach(([key, _]) => {
+    PropertiesService.getScriptProperties().deleteProperty(key);
+  })
 }
 
 const getSessionChannelId = () => {

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -162,7 +162,6 @@ const checkAllReported = (client: SlackClient, channelId: string) => {
 
 const join = (client: SlackClient, channelId: string, userId: string) => {
   const channelState = getChannelState(channelId);
-  let newChannelState = { ...channelState };
   if (!channelState) {
     client.chat.postMessage({ channel: channelId, text: 'no channel state' });
     return;
@@ -177,22 +176,19 @@ const join = (client: SlackClient, channelId: string, userId: string) => {
       text: '既に参加済みです'
     });
   } else {
-    newChannelState.waiting.push(userId);
+    setSessionUserState(channelId, userId, 'waiting');
     client.chat.postMessage({ channel: channelId, text: `:hand: <@${userId}> が参加しました` });
   }
 }
 
 const leave = (client: SlackClient, channelId: string, userId: string) => {
   const channelState: ChannelState = getChannelState(channelId);
-  let newChannelState: ChannelState = { ...channelState }
   if (!channelState) {
     client.chat.postMessage({ channel: channelId, text: 'no channel state' });
     return;
   }
   if (channelState.waiting.includes(userId)) {
-    newChannelState.waiting = channelState.waiting.filter((_userId) => {
-      return _userId !== userId
-    });
+    deleteSessionUserState(userId);
     client.chat.postMessage({ channel: channelId, text: `:wave: <@${userId}> がキャンセルしました` });
     checkAllReported(client, channelId);
   }

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -60,7 +60,7 @@ const initializeSession = (channelId: string) => {
     .timeBased()
     .after(CALL_REMINDER_SECONDS * 1000)
     .create();
-  ScriptApp.newTrigger(continueSession.name)
+  ScriptApp.newTrigger(sendReminderForEndSession.name)
     .timeBased()
     .after(CHECK_TIMEOUT_SECONDS * 1000)
     .create();
@@ -111,7 +111,7 @@ const sendReminderForJoin = async () => {
 }
 
 
-const continueSession = () => {
+const sendReminderForEndSession = () => {
   const scriptLock = LockService.getScriptLock();
   try {
     scriptLock.waitLock(LOCK_TIMEOUT_SECONDS * 1000);
@@ -581,6 +581,6 @@ const handleEmojiChange = (client: SlackClient, event: EmojiChangedEvent) => {
 declare const global: any;
 global.doPost = doPost;
 global.init = init;
-global.continueSession = continueSession;
+global.continueSession = sendReminderForEndSession;
 global.checkParticipants = sendReminderForJoin;
 global.endSession = endSession;


### PR DESCRIPTION
チャンネルの状態管理方法をLockServiceを使わなくて済む様に変更

基本的には1つの大きなPropsだったChannelStateをuserごとのpropに分散させたくらいで、変更箇所が少なくなる様に修正。
（テストが書いてあるわけではなく、大きく変更してしまうと自分の頭では変更が正しく行われているかわからなくなりそうだったため）