### PR TITLE
[fix] globalに追加していた関数名の変更

### DIFF
--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -550,6 +550,6 @@ const handleEmojiChange = (client: SlackClient, event: EmojiChangedEvent) => {
 declare const global: any;
 global.doPost = doPost;
 global.init = init;
-global.continueSession = sendReminderForEndSession;
-global.checkParticipants = sendReminderForJoin;
+global.sendReminderForEndSession = sendReminderForEndSession;
+global.sendReminderForJoin = sendReminderForJoin;
 global.endSession = endSession;


### PR DESCRIPTION
リマインダーを送信する関数名を変更した際に、`global.funcName`のfuncNameが更新されておらず、トリガーからの関数呼び出しが動作しない状態だったため、これを修正。