### PR TITLE
[fix] Change gha for clasp push

### DIFF
--- a/.github/workflows/master-branch-pushed.yml
+++ b/.github/workflows/master-branch-pushed.yml
@@ -43,9 +43,9 @@ jobs:
             "isLocalCreds": false
           }
           EOS
-      - name: Create ~/.clasp.json
+      - name: Create .clasp.json
         run: |
-          cat <<-EOS > ~/.clasp.json
+          cat <<-EOS > ${ GITHUB_WORKSPACE }/.clasp.json
           {
             "scriptId": "${{ secrets.SCRIPT_ID }}",
             "rootDir": "build"

--- a/.github/workflows/master-branch-pushed.yml
+++ b/.github/workflows/master-branch-pushed.yml
@@ -45,7 +45,7 @@ jobs:
           EOS
       - name: Create .clasp.json
         run: |
-          cat <<-EOS > ${ GITHUB_WORKSPACE }/.clasp.json
+          cat <<-EOS > $GITHUB_WORKSPACE/.clasp.json
           {
             "scriptId": "${{ secrets.SCRIPT_ID }}",
             "rootDir": "build"


### PR DESCRIPTION
ed16d8b475a373aab451821860f8f8990508826f でclaspのアップデートをしたところ、GHA実行時に以下のエラーが発生。

> $ /home/runner/work/shujinosuke/shujinosuke/node_modules/.bin/clasp push --force
> No valid .clasp.json project file. You may need to `create` or `clone` a project first.
> error Command failed with exit code 1.


上記エラーを解消するためのPR。