### PR TITLE
[feat] Add meet url to terminate message

### DIFF
--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -156,7 +156,8 @@ const checkAllReported = (client: SlackClient, channelId: string) => {
       text: (
         `:+1: 全員のレポートが完了しました！\n` +
         `:stopwatch: それでは、${readableEndingPeriod}ほど時間を取りますので、全体連絡のある方はお願いします。\n` +
-        `:eyes: また、この時間で皆さんのレポートを読んでコメントしましょう！（もちろん時間が過ぎたあとも続けて:ok:）`
+        `:eyes: また、この時間で皆さんのレポートを読んでコメントしましょう！（もちろん時間が過ぎたあとも続けて:ok:）\n` +
+        `:google: こちらのMeetに参加しておしゃべりもどうぞ！ https://meet.google.com/ofo-ykna-amj`
       )
     })
   }


### PR DESCRIPTION
https://siiibo.slack.com/archives/C0107S3RK24/p1624426225109300 であった要望への対応。

Google MeetのURLをterminateメッセージに追加。