### PR TITLE
[Fix] start command

### DIFF
--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -218,7 +218,7 @@ const getChannelState = (channelId: string): ChannelState => {
   };
 }
 
-const isInMeeting = (channelId: string): boolean => {
+const isStarted = (channelId: string): boolean => {
   const channelState = getChannelState(channelId);
   if (channelState.done.length || channelState.waiting.length) {
     return true;
@@ -407,7 +407,7 @@ const handleAppMention = (slackClient: SlackClient, appMentionEvent: AppMentionE
   const listen = getListen(slackClient, appMentionEvent);
 
   listen(/^開始$/, (client, event) => {
-    if (isInMeeting(event.channel)) {
+    if (isStarted(event.channel)) {
       client.chat.postEphemeral({
         channel: event.channel,
         user: event.user,
@@ -483,7 +483,7 @@ const handleAppMention = (slackClient: SlackClient, appMentionEvent: AppMentionE
         `:pencil: 皆さんコメントや質問をどうぞ！\n` +
         `(チャンネルを読みやすく保つため、「以下にも投稿する：<#${event.channel}>」は使わないようにお願いします)`
     });
-    if (isInMeeting(event.channel)) {
+    if (isStarted(event.channel)) {
       makeDoneFromWaiting(event.channel, event.user);
       checkAllReported(client, event.channel);
     }

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -475,7 +475,6 @@ const handleAppMention = (slackClient: SlackClient, appMentionEvent: AppMentionE
     if (event.edited) {
       return;
     }
-    makeDoneFromWaiting(event.channel, event.user);
     client.chat.postMessage({
       channel: event.channel,
       thread_ts: getThreadTs(event),
@@ -484,7 +483,10 @@ const handleAppMention = (slackClient: SlackClient, appMentionEvent: AppMentionE
         `:pencil: 皆さんコメントや質問をどうぞ！\n` +
         `(チャンネルを読みやすく保つため、「以下にも投稿する：<#${event.channel}>」は使わないようにお願いします)`
     });
-    checkAllReported(client, event.channel);
+    if (isInMeeting(event.channel)) {
+      makeDoneFromWaiting(event.channel, event.user);
+      checkAllReported(client, event.channel);
+    }
   });
 
   listen(/参加/, (client, event) => {

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -218,6 +218,15 @@ const getChannelState = (channelId: string): ChannelState => {
   };
 }
 
+const isInMeeting = (channelId: string): boolean => {
+  const channelState = getChannelState(channelId);
+  if (channelState.done.length || channelState.waiting.length) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
 const deleteChannelState = (channelId: string): void => {
   const properties = PropertiesService.getScriptProperties().getProperties();
   const participants = Object.entries(properties).filter(([key, value]) => {
@@ -398,7 +407,8 @@ const handleAppMention = (slackClient: SlackClient, appMentionEvent: AppMentionE
   const listen = getListen(slackClient, appMentionEvent);
 
   listen(/^開始$/, (client, event) => {
-    if (!getChannelState(event.channel).done.length) {
+    if (isInMeeting(event.channel)) {
+    } else {
       initializeSession(event.channel);
       const readableCheckTimeout = moment
         .duration(CHECK_TIMEOUT_SECONDS, 'seconds')

--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -408,6 +408,13 @@ const handleAppMention = (slackClient: SlackClient, appMentionEvent: AppMentionE
 
   listen(/^開始$/, (client, event) => {
     if (isInMeeting(event.channel)) {
+      client.chat.postEphemeral({
+        channel: event.channel,
+        user: event.user,
+        text:
+          '既に開始しています。\n' +
+          '状態をリセットしてやり直す場合は`リセット`コマンドを実行してください。'
+      });
     } else {
       initializeSession(event.channel);
       const readableCheckTimeout = moment


### PR DESCRIPTION
> 2021/08/04の時点では、未参加状態でもレポートが投稿できる仕様になっている。
> 会議終了後にレポートすると「会議が開始された状態」に変化してしまうため、次の週に `開始` コマンドに反応しなくなってしまっている。

上記バグ修正のためのPR。
