### PR TITLE
[fix] change command to handle slack markup

### DIFF
--- a/src/shujinosuke.ts
+++ b/src/shujinosuke.ts
@@ -363,12 +363,12 @@ const getChannelStateMessage = (channelId: string) => {
 
 const isOriginalCommand = (target: string, commandRegExpString: string) => {
   const regExpString = {
-    slackMarkUp: `([\*_~\`>]|\`{3,})*`,
-    slackMention: `<@\\w+[\\w\\s\|]*>`,
-    commandEnd: `($|[\\s.]+)`, // SlackBotのリマインダーで英字コマンドを呼び出すと文末にピリオド(.)が追加される
+    slackMarkUp: "([*_~`>]|`{3,})*",
+    slackMention: "<@\\w+[\\w\\s\|]*>\\s+",
+    commandEnd: "($|[\\s.]+)", // SlackBotのリマインダーで英字コマンドを呼び出すと文末にピリオド(.)が追加される
   }
   const commandRegExp = new RegExp(
-    `${regExpString.slackMention}\\s+` +
+    regExpString.slackMention +
     regExpString.slackMarkUp +
     commandRegExpString +
     regExpString.slackMarkUp +


### PR DESCRIPTION
2021/10/13のhuddleでキャンセルコマンドに週次之介が反応しない事例が発生した。([Slack](https://siiibo.slack.com/archives/C01AQPDC9S4/p1634103286056400))

markup記法が混じっていると反応しない状態だったので、markup記法にも対応できるように修正。
